### PR TITLE
V1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ has_attached_file :image,
                 ]
             }
         }
-      }
-  }
+    }
 ```
 
 Here, all image versions would be uploaded with a caption taken from the model's caption parameter and 
@@ -125,6 +124,46 @@ be run to crop the photo to a thumbnail and gravitate the center toward the user
 facial recognition features.
 
 The gem-provided default options can not be overridden.
+
+### URL Options
+
+One of Cloudinary's biggest draws is the ability to manipulate images
+on the fly via URL parameters. You can specify the URL options in your
+attachment configuration as well as in-line.  See the Cloudinary
+documentation for a list of all supported parameters.
+
+#### Attachment Configuration
+
+```ruby
+has_attached_file :image
+    :storage => :cloudinary,
+    :styles => { :avatar => '200x200>' },
+    :cloudinary_url_options => {
+        :default => {
+            :secure => true
+        },
+        :styles => {
+            :avatar => {
+                :resource_type => 'raw'
+            }
+        }
+    }
+```
+
+Like upload options, the default options (optional) will be used first
+for all calls, then the style-specific ones, if applicable.
+
+#### In-line Configuration
+
+```ruby
+model.image.url(:avatar, :cloudinary => { :secure => true,
+:resource_type => 'raw' }
+```
+
+These can be use in addition to the URL options provided in the
+attachment configuration, or they can be used standalone. Options
+provided in-line will override any options specified in the attachment
+configuration.
 
 ## Contributing
 

--- a/lib/paperclip/storage/cloudinary.rb
+++ b/lib/paperclip/storage/cloudinary.rb
@@ -68,7 +68,8 @@ module Paperclip
         else
           style = style_or_options
         end
-        ::Cloudinary::Utils.cloudinary_url path(style)
+        inline_opts = options[:cloudinary] || {}
+        ::Cloudinary::Utils.cloudinary_url path(style), cloudinary_url_options(style, inline_opts)
       end
 
       def public_id style
@@ -101,6 +102,21 @@ module Paperclip
       end
 
       private
+
+      def cloudinary_url_options style_name, inline_opts={}
+        url_opts     = @options[:cloudinary_url_options] || {}
+        default_opts = url_opts[:default] || {}
+        style_opts   = url_opts[:styles].try(:[], style_name) || {}
+
+        options = {}
+        [default_opts, style_opts, inline_opts].each do |opts|
+          options.deep_merge!(opts) do |key, existing_value, new_value|
+            new_value.try(:call, style_name, self) || new_value
+          end
+        end
+        options.merge! default_opts
+        options
+      end
 
       def find_credentials creds
         case creds

--- a/lib/paperclip/storage/cloudinary.rb
+++ b/lib/paperclip/storage/cloudinary.rb
@@ -45,7 +45,7 @@ module Paperclip
 
       def flush_deletes
         @queued_for_delete.each do |path|
-          ::Cloudinary::Uploader.destroy path
+          ::Cloudinary::Uploader.destroy path[0..-(File.extname(path).length + 1)]
         end
 
         @queued_for_delete.clear


### PR DESCRIPTION
- In-line/configuraable URL options for cloudinary_url (#2)
- Correct public_id passed for flush_deletes (#3)
